### PR TITLE
cleanup return if appliedmainfestWork is notfound (#312)

### DIFF
--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -167,6 +167,9 @@ func (r *managedReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 // the hash of the given hub host.
 func (r *managedReconcile) cleanUpAppliedManifestWorks(ctx context.Context, klusterlet *operatorapiv1.Klusterlet, config klusterletConfig) error {
 	appliedManifestWorks, err := r.managedClusterClients.appliedManifestWorkClient.List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("unable to list AppliedManifestWorks: %w", err)
 	}


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/ACM-5095

Signed-off-by: Zhiwei Yin <zyin@redhat.com>
(cherry picked from commit 539b6ee334b01ea6d6f571c145c8cdb3fa2b5b54)