### PR TITLE
:bug: create migration cr after the cluster manager cr is applied

### DIFF
--- a/manifests/cluster-manager/cluster-manager-managedclustersetbindings-migration.yaml
+++ b/manifests/cluster-manager/cluster-manager-managedclustersetbindings-migration.yaml
@@ -1,7 +1,7 @@
 apiVersion: migration.k8s.io/v1alpha1
 kind: StorageVersionMigration
 metadata:
-  name: managedclustersetbindings.cluster.open-cluster-management.io
+  name: managedclustersetbindings.v1beta1.cluster.open-cluster-management.io
 spec:
   resource:
     group: cluster.open-cluster-management.io

--- a/manifests/cluster-manager/cluster-manager-managedclustersets-migration.yaml
+++ b/manifests/cluster-manager/cluster-manager-managedclustersets-migration.yaml
@@ -1,7 +1,7 @@
 apiVersion: migration.k8s.io/v1alpha1
 kind: StorageVersionMigration
 metadata:
-  name: managedclustersets.cluster.open-cluster-management.io
+  name: managedclustersets.v1beta1.cluster.open-cluster-management.io
 spec:
   resource:
     group: cluster.open-cluster-management.io

--- a/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -271,10 +271,11 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 
 	if len(errs) == 0 {
 		conds = append(conds, metav1.Condition{
-			Type:    clusterManagerApplied,
-			Status:  metav1.ConditionTrue,
-			Reason:  "ClusterManagerApplied",
-			Message: "Components of cluster manager are applied",
+			Type:               clusterManagerApplied,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ClusterManagerApplied",
+			Message:            "Components of cluster manager are applied",
+			ObservedGeneration: clusterManager.Generation,
 		})
 	} else {
 		if cond := meta.FindStatusCondition(clusterManager.Status.Conditions, clusterManagerApplied); cond != nil {

--- a/pkg/operators/clustermanager/controllers/migrationcontroller/migration_controller_test.go
+++ b/pkg/operators/clustermanager/controllers/migrationcontroller/migration_controller_test.go
@@ -80,9 +80,9 @@ func TestApplyStorageVersionMigrations(t *testing.T) {
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				assertActions(t, actions, "get", "create", "get", "create")
 				actual := actions[1].(clienttesting.CreateActionImpl).Object
-				assertStorageVersionMigration(t, "managedclustersets.cluster.open-cluster-management.io", actual)
+				assertStorageVersionMigration(t, "managedclustersets.v1beta1.cluster.open-cluster-management.io", actual)
 				actual = actions[3].(clienttesting.CreateActionImpl).Object
-				assertStorageVersionMigration(t, "managedclustersetbindings.cluster.open-cluster-management.io", actual)
+				assertStorageVersionMigration(t, "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io", actual)
 			},
 		},
 		{
@@ -90,7 +90,7 @@ func TestApplyStorageVersionMigrations(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 				},
 				&migrationv1alpha1.StorageVersionMigration{
@@ -102,9 +102,9 @@ func TestApplyStorageVersionMigrations(t *testing.T) {
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				assertActions(t, actions, "get", "create", "get", "update")
 				actual := actions[1].(clienttesting.CreateActionImpl).Object
-				assertStorageVersionMigration(t, "managedclustersets.cluster.open-cluster-management.io", actual)
+				assertStorageVersionMigration(t, "managedclustersets.v1beta1.cluster.open-cluster-management.io", actual)
 				actual = actions[3].(clienttesting.UpdateActionImpl).Object
-				assertStorageVersionMigration(t, "managedclustersetbindings.cluster.open-cluster-management.io", actual)
+				assertStorageVersionMigration(t, "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io", actual)
 			},
 		},
 	}
@@ -118,7 +118,8 @@ func TestApplyStorageVersionMigrations(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fakeMigrationClient := fakemigrationclient.NewSimpleClientset(c.existingObjects...)
 
-			err := applyStorageVersionMigrations(context.TODO(), fakeMigrationClient.MigrationV1alpha1(), eventstesting.NewTestingEventRecorder(t))
+			err := applyStorageVersionMigrations(context.TODO(),
+				fakeMigrationClient.MigrationV1alpha1(), eventstesting.NewTestingEventRecorder(t))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -129,10 +130,8 @@ func TestApplyStorageVersionMigrations(t *testing.T) {
 
 func TestRemoveStorageVersionMigrations(t *testing.T) {
 	names := []string{
-		"managedclustersets.cluster.open-cluster-management.io",
-		"managedclustersetbindings.cluster.open-cluster-management.io",
-		"placements.cluster.open-cluster-management.io",
-		"placementdecisions.cluster.open-cluster-management.io",
+		"managedclustersets.v1beta1.cluster.open-cluster-management.io",
+		"managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 	}
 	cases := []struct {
 		name            string
@@ -148,6 +147,11 @@ func TestRemoveStorageVersionMigrations(t *testing.T) {
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+					},
+				},
+				&migrationv1alpha1.StorageVersionMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 				},
 				&migrationv1alpha1.StorageVersionMigration{
@@ -169,11 +173,8 @@ func TestRemoveStorageVersionMigrations(t *testing.T) {
 
 			for _, name := range names {
 				_, err := fakeMigrationClient.MigrationV1alpha1().StorageVersionMigrations().Get(context.TODO(), name, metav1.GetOptions{})
-				if errors.IsNotFound(err) {
-					continue
-				}
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
+				if !errors.IsNotFound(err) {
+					t.Fatalf("expected not found error for %s but got: %v", name, err)
 				}
 			}
 		})
@@ -215,12 +216,12 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 				},
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersets.cluster.open-cluster-management.io",
+						Name: "managedclustersets.v1beta1.cluster.open-cluster-management.io",
 					},
 				},
 			},
@@ -235,7 +236,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -248,7 +249,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 				},
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersets.cluster.open-cluster-management.io",
+						Name: "managedclustersets.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -271,7 +272,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -284,7 +285,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 				},
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersets.cluster.open-cluster-management.io",
+						Name: "managedclustersets.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -307,7 +308,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -320,7 +321,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 				},
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersets.cluster.open-cluster-management.io",
+						Name: "managedclustersets.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -343,7 +344,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersetbindings.cluster.open-cluster-management.io",
+						Name: "managedclustersetbindings.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{
@@ -356,7 +357,7 @@ func Test_syncStorageVersionMigrationsCondition(t *testing.T) {
 				},
 				&migrationv1alpha1.StorageVersionMigration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "managedclustersets.cluster.open-cluster-management.io",
+						Name: "managedclustersets.v1beta1.cluster.open-cluster-management.io",
 					},
 					Status: migrationv1alpha1.StorageVersionMigrationStatus{
 						Conditions: []migrationv1alpha1.MigrationCondition{


### PR DESCRIPTION
This PR will:
- add the `ObservedGeneration` field for the cluster manager Applied condition
- wait the current generation cluster manager is applied(`Applied` condition is true and the `ObservedGeneration`==`Generation`), then create the migration CR
- add version info v1beta1 into tho the migration CR names