### PR TITLE
Ignore appliedmanifestwork crd not found error when checking managed cluster connectivity

### DIFF
--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -211,6 +211,10 @@ func (r *klusterletCleanupController) checkConnectivity(ctx context.Context,
 	if err == nil {
 		return true, nil
 	}
+	if errors.IsNotFound(err) {
+		klog.Infof("AppliedManifestWork not found, klusterlet %s", klusterlet.Name)
+		return true, nil
+	}
 
 	// if the managed cluster is destroyed, the returned err is TCP timeout or TCP no such host,
 	// the k8s.io/apimachinery/pkg/api/errors.IsTimeout,IsServerTimeout can not match this error


### PR DESCRIPTION
issue reference: https://issues.redhat.com/browse/OHSS-36145